### PR TITLE
Update Dependencies for Workflow "Android CI"

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: set up JDK 17
       uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
This updates the dependencies for the github workflow "Android CI"

> [!NOTE]
> The build error that continues to be issued is not due to the Github workflow but rather to an error in the programming code (which I wanted to fix with #22)